### PR TITLE
Remove LKGR support

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
           <span><a href="https://github.com/beaufortfrancois/download-chromium/issues">File a bug report</a></span>
         </p>
         <footer>
+          <!--
           {% if platform %}
           <div>
             <span>Build Types:</span>
@@ -206,6 +207,7 @@
           {% endfor %}
           </div>
           {% endif %}
+          -->
           <div>
             <span>Supported Platforms:</span>
           {% for p in platforms %}

--- a/utils.py
+++ b/utils.py
@@ -19,7 +19,8 @@ class ChromiumBuildType(object):
         return self.name
 
 SNAPSHOTS    = ChromiumBuildType('snapshots',   'Latest')
-CONTINUOUS   = ChromiumBuildType('continuous', 'Last Known Good Revision')
+#TODO: Clean up build types once we're sure it's not needed anymore
+#CONTINUOUS   = ChromiumBuildType('continuous', 'Last Known Good Revision')
 
 def get_build_type(name):
     try:


### PR DESCRIPTION
This CL removes temporarily LKGR support. If no one complains for a month, I'll clean up the `build_type` dict and the rest of the app. For now, it simply hides the LKGR bit.

FIX: https://github.com/beaufortfrancois/download-chromium/pull/29

R: @paulirish 