### PR TITLE
Update build URL for Cr-Commit-Position change

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from google.appengine.api import urlfetch
 
 
 LAST_REVISION_TEMPLATE = 'https://commondatastorage.googleapis.com/chromium-browser-%(build_type)s/%(platform)s/LAST_CHANGE'
-LAST_BUILD_TEMPLATE = 'https://commondatastorage.googleapis.com/chromium-browser-%(build_type)s/%(platform)s/%(revision)s/%(zip_name)s'
+LAST_BUILD_TEMPLATE = 'https://commondatastorage.googleapis.com/chromium-browser-%(build_type)s/%(platform)s/refs_heads_main-%(revision)s/%(zip_name)s'
 
 build_types = []
 


### PR DESCRIPTION
Fixes #67

I assume this has to do with the `Cr-Commit-Position` change to `refs/heads/main` which happened about the same time as the `refs_heads_main-####` builds started showing up in the snapshots, but I have no idea if this was intended/acceptable or if it should be fixed upstream somewhere instead.

Confirmed that this works for all platforms _except_ `Linux` which is the only platform currently still working, but `Linux` also downloads a snapshot from 2016, so I'm not sure what you'd want to do there (`Linux_x64` and `Linux_ChromiumOS_Full` work as expected with this change).