### PR TITLE
Revert "Update build URL for Cr-Commit-Position change"

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from google.appengine.api import urlfetch
 
 
 LAST_REVISION_TEMPLATE = 'https://commondatastorage.googleapis.com/chromium-browser-%(build_type)s/%(platform)s/LAST_CHANGE'
-LAST_BUILD_TEMPLATE = 'https://commondatastorage.googleapis.com/chromium-browser-%(build_type)s/%(platform)s/refs_heads_main-%(revision)s/%(zip_name)s'
+LAST_BUILD_TEMPLATE = 'https://commondatastorage.googleapis.com/chromium-browser-%(build_type)s/%(platform)s/%(revision)s/%(zip_name)s'
 
 build_types = []
 


### PR DESCRIPTION
Reverts beaufortfrancois/download-chromium#68

It seems like `refs_heads_main-` prefixed URLs are not used anymore. Feel free to revert if it happens again.